### PR TITLE
MLC Integration and bug fixes

### DIFF
--- a/env_sample.txt
+++ b/env_sample.txt
@@ -10,9 +10,14 @@ OPENAI_API_KEY="sk-xxxxx"
 FIREWORKS_API_BASE="https://api.fireworks.ai/inference/v1"
 FIREWORKS_API_KEY="xxxxx"
 
+# MLC-LLM Endpoint
+MLC_API_BASE="http://127.0.0.1:8000/v1"
+MLC_API_KEY="123"
+
 #vLLM Endpoint
-VLLM_API_BASE="https://localhost/v1"
-VLLM_API_KEY="xxxxx'
+VLLM_API_BASE="http://127.0.0.1:8000/v1"
+VLLM_API_KEY="123"
+
 
 # Huggingface  Text Generation Inference
 TGI_API_BASE="http://localhost:8001"


### PR DESCRIPTION
This PR integrates MLC LLM into llmperf, and meanwhile fixes a few existing bugs, including
- outdated use of openai package,
- could not ensure random number determinism across runs even with seed.

To run benchmark for MLC LLM, run the following commands in two shells:
```
python -m mlc_chat.serve.server --model "Llama-2-7b-chat-hf-q0f16"
python llmperf.py -f mlc-llm -m Llama-2-7b-chat-hf-q0f16 --concur-requests 32
```

To run benchmark with vLLM, run the following two commands in two shells:
```
python -m vllm.entrypoints.openai.api_server --model /models/Llama-2-7b-chat-hf --dtype=float16
python llmperf.py -f vllm -m /models/Llama-2-7b-chat-hf --concur-requests 32
```
(note: `/models/Llama-2-7b-chat` denotes the path to llama2-7b.)

Change `--concur-requests` to different values (8, 16, 32, 64) to evaluate different scenarios.